### PR TITLE
Datazoom fixes

### DIFF
--- a/src/component/dataZoom/InsideZoomView.ts
+++ b/src/component/dataZoom/InsideZoomView.ts
@@ -117,6 +117,33 @@ const getRangeHandlers: {
         range[0] = (range[0] - percentPoint) * scale + percentPoint;
         range[1] = (range[1] - percentPoint) * scale + percentPoint;
 
+        // Correlate zoom ratio if there are more than one axis. It is to prevent zooming disproportion
+        if ((e as any).context.batch?.length) {
+            const x = (e as any).context.batch[0];
+            const xSpan = x.end - x.start;
+            if (Math.round(range[1] - range[0]) !== Math.round(xSpan)) {
+                // Disproportion happens and needs to be fixed
+                const centerPoint = (range[1] - range[0]) / 2;
+                const xSpanHalf = xSpan / 2;
+                if (xSpanHalf > centerPoint && xSpanHalf > 100 - centerPoint) {
+                    range[0] = 0;
+                    range[1] = 100;
+                }
+                else if (xSpanHalf > centerPoint) {
+                    range[0] = 0;
+                    range[1] = Math.min(100, xSpan);
+                }
+                else if (xSpanHalf > 100 - centerPoint) {
+                    range[0] = Math.max(0, 100 - xSpan);
+                    range[1] = 100;
+                }
+                else {
+                    range[0] = centerPoint - xSpanHalf;
+                    range[1] = centerPoint + xSpanHalf;
+                }
+            }
+        }
+
         // Restrict range.
         const minMaxSpan = this.dataZoomModel.findRepresentativeAxisProxy().getMinMaxSpan();
 

--- a/src/component/dataZoom/InsideZoomView.ts
+++ b/src/component/dataZoom/InsideZoomView.ts
@@ -120,6 +120,11 @@ const getRangeHandlers: {
         // Restrict range.
         const minMaxSpan = this.dataZoomModel.findRepresentativeAxisProxy().getMinMaxSpan();
 
+        // Stop moving when reaching max or min span
+        if (minMaxSpan.minSpan >= range[1] - range[0] || minMaxSpan.maxSpan <= range[1] - range[0]) {
+            return;
+        }
+
         sliderMove(0, range, [0, 100], 0, minMaxSpan.minSpan, minMaxSpan.maxSpan);
 
         this.range = range;

--- a/src/component/dataZoom/roams.ts
+++ b/src/component/dataZoom/roams.ts
@@ -124,6 +124,9 @@ function createCoordSysRecord(api: ExtensionAPI, coordSysModel: CoordinateSystem
     each(['pan', 'zoom', 'scrollMove'] as const, function (eventName) {
         controller.on(eventName, function (event) {
             const batch: DataZoomPayloadBatchItem[] = [];
+            if (eventName === 'zoom') {
+                (event as any).context = { batch };
+            }
 
             coordSysRecord.dataZoomInfoMap.each(function (dzInfo) {
                 // Check whether the behaviors (zoomOnMouseWheel, moveOnMouseMove,


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [x] bug fixing
- [ ] new feature
- [ ] others



### What does this PR do?

<!-- USE ONE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->
This PR fixes some zoom issues in DataZoom


### Fixed issues

- Fixed sideway scrolling when reaching max or min span in DataZoom
- Fixed zooming disproportion in DataZoom if there is more than one axis (keep the same ratio for x and y axis)


## Details

### Before: What was the problem?
1.  When using mouse wheel to zoom in/out, it will start sideway scrolling when it reaches the max/min span.
![zoom in out before](https://github.com/pulsarplatform/echarts/assets/126215214/595860a4-3e59-4e7b-bceb-8b1832eb13c9)

2. Sometimes on zoom out, the zoom ration will become inconsistent and causing a disproportional view.
<img width="794" alt="before" src="https://github.com/pulsarplatform/echarts/assets/126215214/ea1e85d1-4cbf-4921-b2d4-67dbfdc3647c">

### After: How does it behave after the fixing?

1. Fixed effect: it will stop at the max/min span
![zoom in out after](https://github.com/pulsarplatform/echarts/assets/126215214/fee8ab4b-2852-46fc-8d86-14296c7dfead)

2. Fixed effect: Two axes keep the same ratio
<img width="794" alt="after" src="https://github.com/pulsarplatform/echarts/assets/126215214/8d8f3969-c587-4efa-9729-57e3867daace">



## Document Info

One of the following should be checked.

- [x] This PR doesn't relate to document changes
- [ ] The document should be updated later
- [ ] The document changes have been made in apache/echarts-doc#xxx



## Misc

### ZRender Changes

- [ ] This PR depends on ZRender changes (ecomfe/zrender#xxx).

### Related test cases or examples to use the new APIs

N.A.



## Others

### Merging options

- [x] Please squash the commits into a single one when merging.

### Other information
